### PR TITLE
Remove invalid options for exfat filesystem

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -48,7 +48,7 @@ static struct FS supported_fs[] = {
     },
     {
         .fsname = "exfat",
-        .options = "nosuid,nodev,user,quiet,nonempty",
+        .options = "nosuid,nodev,user",
         .support_ugid = 1,
         .umask = "077",
         .iocharset_format = ",iocharset=%s",


### PR DESCRIPTION
According to the history, the exfat support comes from the a patch I proposed in the Debian bug tracker (https://bugs.debian.org/755434) [note that I'm not the author, I got it from Ubuntu]
I was using this patch locally, but, since 2021, I needed to update it in order to remove invalid options (before, mount accepted and ignored them silently).

Regards,
  Vincent